### PR TITLE
Use @autoclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Unless.swift is a µ-framework, or rather an n-framework, that provide syntactic sugar to write code that reads like "unless this do that".
 
 ```swift
-unless({ condition }) { 
+unless(condition) { 
   doSomething()
 }
 ```

--- a/Sources/Unless.swift
+++ b/Sources/Unless.swift
@@ -1,9 +1,7 @@
-/// Execute the given closure `do` only if the result of the first argument
+/// Execute the given closure only if the result of the first argument
 /// is false
-func unless(_ condition: () -> Bool, do closure: @escaping () -> ()) {
-  guard condition() == false else {
-    return
-  }
-
-  closure()
+func unless(_ condition: @autoclosure () -> Bool, _ closure: () -> Void) {
+    if condition() == false {
+        closure()
+    }
 }

--- a/Sources/Unless.swift
+++ b/Sources/Unless.swift
@@ -1,7 +1,9 @@
 /// Execute the given closure only if the result of the first argument
 /// is false
 func unless(_ condition: @autoclosure () -> Bool, _ closure: () -> Void) {
-    if condition() == false {
-        closure()
+    guard condition() == false else {
+        return
     }
+
+    closure()
 }

--- a/Sources/Unless.swift
+++ b/Sources/Unless.swift
@@ -1,9 +1,9 @@
 /// Execute the given closure only if the result of the first argument
 /// is false
 func unless(_ condition: @autoclosure () -> Bool, _ closure: () -> Void) {
-    guard condition() == false else {
-        return
-    }
+  guard condition() == false else {
+    return
+  }
 
-    closure()
+  closure()
 }

--- a/Tests/UnlessTests/UnlessTests.swift
+++ b/Tests/UnlessTests/UnlessTests.swift
@@ -1,38 +1,23 @@
 import XCTest
 @testable import Unless
 
-class UnlessTests: XCTestCase {
-  func testItCallsTheGivenClosureIfConditionIsFalse() {
-    var called = false
-    unless({ return false }, do: { called = true })
-    XCTAssertTrue(called, "Expected closure to run and set called to true")
-  }
+final class UnlessTests: XCTestCase {
+    func testItCallsTheGivenClosureIfConditionIsFalse() {
+        var called = false
+        unless(false) { called = true }
+        XCTAssertTrue(called, "Expected closure to run and set called to true")
+    }
 
-  func testItDoesNotCallTheGivenClosureIfConditionIsTrue() {
-    var called = false
-    unless({ return true }, do: { called = true })
-    XCTAssertFalse(called, "Expected closure to not run")
-  }
+    func testItDoesNotCallTheGivenClosureIfConditionIsTrue() {
+        var called = false
+        unless(true) { called = true }
+        XCTAssertFalse(called, "Expected closure to not run")
+    }
 
-  func testWorksWithSwiftImplicitReturn() {
-    var called = false
-    unless({ false }, do: { called = true })
-    XCTAssertTrue(called, "Expected closure to run")
-  }
-
-  func testWorksWithSwiftImplicitReturnWithValue() {
-    var called = false
-    let value = false
-    unless({ value }, do: { called = true })
-    XCTAssertTrue(called, "Expected closure to run")
-  }
-
-  static var allTests : [(String, (UnlessTests) -> () throws -> Void)] {
-    return [
-      ("testItCallsTheGivenClosureIfConditionIsFalse", testItCallsTheGivenClosureIfConditionIsFalse),
-      ("testItDoesNotCallTheGivenClosureIfConditionIsTrue", testItDoesNotCallTheGivenClosureIfConditionIsTrue),
-      ("testWorksWithSwiftImplicitReturn", testWorksWithSwiftImplicitReturn),
-      ("testWorksWithSwiftImplicitReturnWithValue", testWorksWithSwiftImplicitReturnWithValue)
-    ]
-  }
+    static var allTests : [(String, (UnlessTests) -> () throws -> Void)] {
+        return [
+            ("testItCallsTheGivenClosureIfConditionIsFalse", testItCallsTheGivenClosureIfConditionIsFalse),
+            ("testItDoesNotCallTheGivenClosureIfConditionIsTrue", testItDoesNotCallTheGivenClosureIfConditionIsTrue)
+        ]
+    }
 }

--- a/Tests/UnlessTests/UnlessTests.swift
+++ b/Tests/UnlessTests/UnlessTests.swift
@@ -14,10 +14,24 @@ final class UnlessTests: XCTestCase {
         XCTAssertFalse(called, "Expected closure to not run")
     }
 
+    func testItCallsTheGivenClosureIfAutoclosureConditionIsFalse() {
+        var called = false
+        unless(1 > 2) { called = true }
+        XCTAssertTrue(called, "Expected closure to run and set called to true")
+    }
+
+    func testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue() {
+        var called = false
+        unless(2 > 1) { called = true }
+        XCTAssertFalse(called, "Expected closure to not run")
+    }
+
     static var allTests : [(String, (UnlessTests) -> () throws -> Void)] {
         return [
             ("testItCallsTheGivenClosureIfConditionIsFalse", testItCallsTheGivenClosureIfConditionIsFalse),
-            ("testItDoesNotCallTheGivenClosureIfConditionIsTrue", testItDoesNotCallTheGivenClosureIfConditionIsTrue)
+            ("testItDoesNotCallTheGivenClosureIfConditionIsTrue", testItDoesNotCallTheGivenClosureIfConditionIsTrue),
+            ("testItCallsTheGivenClosureIfAutoclosureConditionIsFalse", testItCallsTheGivenClosureIfAutoclosureConditionIsFalse),
+            ("testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue", testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue)
         ]
     }
 }

--- a/Tests/UnlessTests/UnlessTests.swift
+++ b/Tests/UnlessTests/UnlessTests.swift
@@ -2,36 +2,36 @@ import XCTest
 @testable import Unless
 
 final class UnlessTests: XCTestCase {
-    func testItCallsTheGivenClosureIfConditionIsFalse() {
-        var called = false
-        unless(false) { called = true }
-        XCTAssertTrue(called, "Expected closure to run and set called to true")
-    }
+  func testItCallsTheGivenClosureIfConditionIsFalse() {
+    var called = false
+    unless(false) { called = true }
+    XCTAssertTrue(called, "Expected closure to run and set called to true")
+  }
 
-    func testItDoesNotCallTheGivenClosureIfConditionIsTrue() {
-        var called = false
-        unless(true) { called = true }
-        XCTAssertFalse(called, "Expected closure to not run")
-    }
+  func testItDoesNotCallTheGivenClosureIfConditionIsTrue() {
+    var called = false
+    unless(true) { called = true }
+    XCTAssertFalse(called, "Expected closure to not run")
+  }
 
-    func testItCallsTheGivenClosureIfAutoclosureConditionIsFalse() {
-        var called = false
-        unless(1 > 2) { called = true }
-        XCTAssertTrue(called, "Expected closure to run and set called to true")
-    }
+  func testItCallsTheGivenClosureIfAutoclosureConditionIsFalse() {
+    var called = false
+    unless(1 > 2) { called = true }
+    XCTAssertTrue(called, "Expected closure to run and set called to true")
+  }
 
-    func testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue() {
-        var called = false
-        unless(2 > 1) { called = true }
-        XCTAssertFalse(called, "Expected closure to not run")
-    }
+  func testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue() {
+    var called = false
+    unless(2 > 1) { called = true }
+    XCTAssertFalse(called, "Expected closure to not run")
+  }
 
-    static var allTests : [(String, (UnlessTests) -> () throws -> Void)] {
-        return [
-            ("testItCallsTheGivenClosureIfConditionIsFalse", testItCallsTheGivenClosureIfConditionIsFalse),
-            ("testItDoesNotCallTheGivenClosureIfConditionIsTrue", testItDoesNotCallTheGivenClosureIfConditionIsTrue),
-            ("testItCallsTheGivenClosureIfAutoclosureConditionIsFalse", testItCallsTheGivenClosureIfAutoclosureConditionIsFalse),
-            ("testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue", testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue)
-        ]
-    }
+  static var allTests : [(String, (UnlessTests) -> () throws -> Void)] {
+    return [
+      ("testItCallsTheGivenClosureIfConditionIsFalse", testItCallsTheGivenClosureIfConditionIsFalse),
+      ("testItDoesNotCallTheGivenClosureIfConditionIsTrue", testItDoesNotCallTheGivenClosureIfConditionIsTrue),
+      ("testItCallsTheGivenClosureIfAutoclosureConditionIsFalse", testItCallsTheGivenClosureIfAutoclosureConditionIsFalse),
+      ("testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue", testItDoesNotCallTheGivenClosureIfAutoclosureConditionIsTrue)
+    ]
+  }
 }


### PR DESCRIPTION
Simple change to use an `@autoclosure` for the condition, allowing
```
unless({ condition }) { ... }
```
to be called like this
```
unless(condition) { ... }
```